### PR TITLE
🔨 Removed black and use ruff-format instead

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,8 @@ repos:
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.9.1
     hooks:
     -   id: ruff
         args: [--fix, --show-fixes]
--   repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-    -   id: black
+    -   id: ruff-format

--- a/hispanie/errors.py
+++ b/hispanie/errors.py
@@ -20,7 +20,6 @@ class Error(Exception):
 
 
 class NoDataFound(Error):
-
     code = 1000
     reason = "no-data-found"
     description = "No data found in DB."

--- a/hispanie/model/file.py
+++ b/hispanie/model/file.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
 
 class File(Base, Resource):
-
     __tablename__ = "file"
 
     id: Mapped[str] = mapped_column(

--- a/hispanie/model/resource.py
+++ b/hispanie/model/resource.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 
 class Resource:
-
     description: Mapped[str | None] = mapped_column(String, nullable=True)
 
     creation_date: Mapped[datetime] = mapped_column(

--- a/hispanie/model/tag.py
+++ b/hispanie/model/tag.py
@@ -9,7 +9,6 @@ from .resource import Resource
 
 
 class Tag(Base, Resource):
-
     __tablename__ = "tag"
 
     id: Mapped[str] = mapped_column(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
-[tool.black]
-line-length = 100
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+preview = true
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
We can now use ruff for formattage without need for black